### PR TITLE
Specified correct url for Subscription method

### DIFF
--- a/examples/subscription.js
+++ b/examples/subscription.js
@@ -14,6 +14,7 @@ const data = {
   order_desc: 'test order',
   currency: 'USD',
   amount: 1000,
+  subscription: 'Y',
   recurring_data:
   {
     every: 5,
@@ -24,7 +25,7 @@ const data = {
     Readonly: 'n'
   }
 }
-fondy.Subscription(data).then(data => {
+fondy.Checkout(data).then(data => {
   console.log(data)
 }).catch((error) => {
   console.log(error)

--- a/lib/index.js
+++ b/lib/index.js
@@ -257,10 +257,9 @@ CloudIpsp.prototype.Settlement = function (data) {
 CloudIpsp.prototype.Subscription = function (data) {
   this.config.protocol = '2.0'
   this.config.contentType = 'json'
-  data.subscription = 'Y'
   const request = this.getImportantParams(data, false)
   const options = {
-    path: 'checkout/url/',
+    path: 'subscription/',
     body: request
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,7 @@ describe('Main API', function () {
         order_desc: 'test order',
         currency: 'USD',
         amount: 1000,
+        subscription: 'Y',
         recurring_data:
           {
             every: 5,


### PR DESCRIPTION
Hey guys,

I had to adjust your SDK a bit as it turns out that the Subscription method is using the checkout URL. Well, it's clear that you can create a subscription order using the checkout URL by specifying `subscription: 'Y'` and the `recurring_data` but still, whenever we need to use /subscription/ endpoint, e.g. for stopping, starting it should have the correct method in the SDK I guess.

Thanks.