### PR TITLE
Fix: expose response on error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -82,12 +82,14 @@ class CloudIpsp {
     const data = await request(options)
     const response = util.getConvertedResponse(type, data, this.config.protocol)
     if (response.error_code) {
-      throw new Error(
+      const error = new Error(
         'Response status is failure\n' +
          `error_code: ${response.error_code}\n` +
          `request_id: ${response.request_id}\n` +
          `error_message: ${response.error_message}\n`
       )
+      error.response = response
+      throw error
     } else {
       return response
     }


### PR DESCRIPTION
Expose `response` on the error to access `error_code` and other parameters. Otherwise, it is needed to parse the error. 

I believe it is essential to expose the `response` because users can choose what to do depending on the `error_code`.   